### PR TITLE
urldecode_fix

### DIFF
--- a/src/mimeTools.cpp
+++ b/src/mimeTools.cpp
@@ -337,7 +337,8 @@ void convertURLDecode()
   if (bufLength == 0) return;
 
   char * selectedText = new char[bufLength];
-  char * pDecodedText = new char[bufLength];
+  // fix https://github.com/npp-plugins/mimetools/issues/8 bug
+  char * pDecodedText = new char[bufLength*2];
   ::SendMessage(hCurrScintilla, SCI_GETSELTEXT, 0, (LPARAM)selectedText);
 
   // this line is added to walk around Scintilla 201 bug


### PR DESCRIPTION
The problem is that in decode time, decoded text length over than encoded text length.