### PR TITLE
Add "URL Encode Extended" command

### DIFF
--- a/src/mimeTools.cpp
+++ b/src/mimeTools.cpp
@@ -54,14 +54,15 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD reasonForCall, LPVOID /*lpReserved*/
 
 			funcItem[10]._pFunc = NULL;
 			funcItem[11]._pFunc = convertURLMinEncode;
-			funcItem[12]._pFunc = convertURLFullEncode;
-			funcItem[13]._pFunc = convertURLDecode;
+			funcItem[12]._pFunc = convertURLEncodeExtended;
+			funcItem[13]._pFunc = convertURLFullEncode;
+			funcItem[14]._pFunc = convertURLDecode;
 			
-			funcItem[14]._pFunc = NULL;
-			funcItem[15]._pFunc = convertSamlDecode;
+			funcItem[15]._pFunc = NULL;
+			funcItem[16]._pFunc = convertSamlDecode;
 
-			funcItem[16]._pFunc = NULL;
-			funcItem[17]._pFunc = about;
+			funcItem[17]._pFunc = NULL;
+			funcItem[18]._pFunc = about;
 
 			lstrcpy(funcItem[0]._itemName, TEXT("Base64 Encode"));
 			lstrcpy(funcItem[1]._itemName, TEXT("Base64 Encode with padding"));
@@ -78,17 +79,18 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD reasonForCall, LPVOID /*lpReserved*/
 			
 			lstrcpy(funcItem[10]._itemName, TEXT("-SEPARATOR-"));
 
-			lstrcpy(funcItem[11]._itemName, TEXT("URL Encode"));
-			lstrcpy(funcItem[12]._itemName, TEXT("Full URL Encode"));
-			lstrcpy(funcItem[13]._itemName, TEXT("URL Decode"));
+			lstrcpy(funcItem[11]._itemName, TEXT("URL Encode (RFC1738)"));
+			lstrcpy(funcItem[12]._itemName, TEXT("URL Encode (Extended)"));
+			lstrcpy(funcItem[13]._itemName, TEXT("Full URL Encode"));
+			lstrcpy(funcItem[14]._itemName, TEXT("URL Decode"));
 			
-			lstrcpy(funcItem[14]._itemName, TEXT("-SEPARATOR-"));
+			lstrcpy(funcItem[15]._itemName, TEXT("-SEPARATOR-"));
 
-			lstrcpy(funcItem[15]._itemName, TEXT("SAML Decode"));
+			lstrcpy(funcItem[16]._itemName, TEXT("SAML Decode"));
 			
-			lstrcpy(funcItem[16]._itemName, TEXT("-SEPARATOR-"));
+			lstrcpy(funcItem[17]._itemName, TEXT("-SEPARATOR-"));
 
-			lstrcpy(funcItem[17]._itemName, TEXT("About"));
+			lstrcpy(funcItem[18]._itemName, TEXT("About"));
 
 			funcItem[0]._init2Check = false;
 			funcItem[1]._init2Check = false;
@@ -298,15 +300,20 @@ void convertToAsciiFromBase64_whitespaceReset()
 
 void convertURLMinEncode()
 {
-  convertURLEncode (false);
+	convertURLEncode (UrlEncodeMethod::RFC1738);
+}
+
+void convertURLEncodeExtended()
+{
+	convertURLEncode (UrlEncodeMethod::extended);
 }
 
 void convertURLFullEncode()
 {
-  convertURLEncode (true);
+	convertURLEncode (UrlEncodeMethod::full);
 }
 
-void convertURLEncode (bool encodeAll)
+void convertURLEncode (UrlEncodeMethod method)
 {
   HWND hCurrScintilla = getCurrentScintillaHandle();
   size_t selBufLen = ::SendMessage(hCurrScintilla, SCI_GETSELTEXT, 0, 0);
@@ -320,7 +327,7 @@ void convertURLEncode (bool encodeAll)
   size_t destBufLen = strlen(selectedText) * 3 + 1;
   char* pEncodedText = new char[destBufLen];
   
-  int len = AsciiToUrl(pEncodedText, selectedText, int(destBufLen), encodeAll);
+  int len = AsciiToUrl(pEncodedText, selectedText, int(destBufLen), method);
 
   size_t start = ::SendMessage(hCurrScintilla, SCI_GETSELECTIONSTART, 0, 0);
   size_t end = ::SendMessage(hCurrScintilla, SCI_GETSELECTIONEND, 0, 0);

--- a/src/mimeTools.h
+++ b/src/mimeTools.h
@@ -30,7 +30,7 @@
 #define IDC_STATIC -1
 #endif
 
-
+#include "url.h"
 
 void convertToBase64FromAscii();
 void convertToBase64FromAscii_pad();
@@ -42,8 +42,9 @@ void convertToAsciiFromBase64_whitespaceReset();
 void convertToQuotedPrintable();
 void convertToAsciiFromQuotedPrintable();
 void convertURLMinEncode();
+void convertURLEncodeExtended();
 void convertURLFullEncode();
-void convertURLEncode(bool);
+void convertURLEncode(UrlEncodeMethod method);
 void convertURLDecode();
 void convertSamlDecode();
 void convertURLDecode();

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -16,25 +16,85 @@
 
 
 #include <string.h>
+#include <string>
 #include <ctype.h>
 
 #include "url.h"
 
-// These characters must be encoded in a URL, as per RFC1738
-static const char gReservedAscii[] = "<>\"#%{}|\\^~[]`;/?:@=& ";  
+
+// Unsafe:
+// 
+// Characters can be unsafe for a number of reasons.The space
+// character is unsafe because significant spaces may disappearand
+// insignificant spaces may be introduced when URLs are transcribed or
+// typeset or subjected to the treatment of word - processing programs.
+// The characters "<" and ">" are unsafe because they are used as the
+// delimiters around URLs in free text; the quote mark(""") is used to
+//     delimit URLs in some systems.The character "#" is unsafe and should
+//     always be encoded because it is used in World Wide Web and in other
+//     systems to delimit a URL from a fragment / anchor identifier that might
+//     follow it.The character "%" is unsafe because it is used for
+//     encodings of other characters.Other characters are unsafe because
+//     gatewaysand other transport agents are known to sometimes modify
+//     such characters.These characters are "{", "}", "|", "\", " ^ ", "~",
+//     "[", "]", and "`".
+// 
+//     All unsafe characters must always be encoded within a URL.For
+//     example, the character "#" must be encoded within URLs even in
+//     systems that do not normally deal with fragment or anchor
+//     identifiers, so that if the URL is copied into another system that
+//     does use them, it will not be necessary to change the URL encoding.
+//
+// Reserved:
+//
+// Many URL schemes reserve certain characters for a special meaning :
+// their appearance in the scheme - specific part of the URL has a
+// designated semantics.If the character corresponding to an octet is
+// reserved in a scheme, the octet must be encoded.The characters ";",
+// "/", "?", ":", "@", "=" and "&" are the characters which may be
+// reserved for special meaning within a scheme.No other characters may
+// be reserved within a scheme.
+//
+// Usually a URL has the same interpretation when an octet is
+// represented by a characterand when it encoded.However, this is not
+// true for reserved characters : encoding a character reserved for a
+// particular scheme may change the semantics of a URL.
+// 
+// Thus, only alphanumerics, the special characters "$-_.+!*'(),", and
+// reserved characters used for their reserved purposes may be used
+// unencoded within a URL.
+// 
+// On the other hand, characters that are not required to be encoded
+// (including alphanumerics) may be encoded within the scheme - specific
+// part of a URL, as long as they are not being used for a reserved
+// purpose.
+//
+// https://datatracker.ietf.org/doc/html/rfc1738
+
+// These "unsafe" characters must be encoded in a URL, as per RFC1738
+static const char gReservedAscii[] = "<>\"#%{}|\\^~[]`;/?:@=& ";
+
+// In order to follow the "standard" implementations,
+// the following characters which are allowed to not be encoded (according RFC 1738)
+// can be included into "must be encoded" characters.
+static const char gExtendedChar[] = "!*'()+$,";
+
 static const char gHexChar[] = "0123456789ABCDEF";
 
-int AsciiToUrl (char* dest, const char* src, int destSize, bool encodeAll)
+int AsciiToUrl (char* dest, const char* src, int destSize, UrlEncodeMethod method)
 {
   int i;
-
   memset (dest, 0, destSize);
+  std::string reservedAscii = gReservedAscii;
+  
+  if (method == UrlEncodeMethod::extended)
+      reservedAscii += gExtendedChar;
 
   for (i = 0; (i < (destSize - 2)) && *src; ++i, ++src)
   {
     // Encode source if it is a reserved or non-printable character.
     //
-    if (encodeAll || (strchr (gReservedAscii, *src) != 0) || !isprint(*src))
+    if (method == UrlEncodeMethod::full || (strchr (reservedAscii.c_str(), *src) != 0) || !isprint(*src))
     {
       *dest++ = '%';
       *dest++ = gHexChar [((*src >> 4) & 0x0f)];

--- a/src/url.h
+++ b/src/url.h
@@ -18,7 +18,9 @@
 #ifndef NPP_URL_H
 #define NPP_URL_H
 
-int AsciiToUrl (char* dest, const char* src, int destSize, bool encodeAll);
+enum UrlEncodeMethod { RFC1738, extended, full };
+
+int AsciiToUrl (char* dest, const char* src, int destSize, UrlEncodeMethod method);
 int UrlToAscii (char* dest, const char* src, int destSize);
 
 #endif //NPP_URL_H


### PR DESCRIPTION
Current "URL Encode" command of which the implementation follows RFC 1738 is renameed to "URL Encode (RFC 1738)". The new added command "URL Encode (Extended)" follows the most popular implementation which encode also the following characters "$-_.+!*'(),".

Fix #28